### PR TITLE
Document Logstash host should use TCP protocl

### DIFF
--- a/docs/static/advanced-pipeline.asciidoc
+++ b/docs/static/advanced-pipeline.asciidoc
@@ -34,6 +34,22 @@ To install Filebeat on your data source machine, download the appropriate packag
 {filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start] for additional
 installation instructions.
 
+[WARNING]
+==================================================
+
+{filebeat-ref}/filebeat-installation-configuration.html[Filebeat quick start] contains setup that is not needed for this
+setup and can *make things not work* here. For simplicity, simply skip the link, install Filebeat with
+
+[source,shell]
+-----------------------------------------------------------------------------------------
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.9.2-amd64.deb
+sudo dpkg -i filebeat-8.9.2-amd64.deb
+-----------------------------------------------------------------------------------------
+
+, and proceed with the following instructions
+
+==================================================
+
 After installing Filebeat, you need to configure it. Open the `filebeat.yml` file located in your Filebeat installation
 directory, and replace the contents with the following lines. Make sure `paths` points to the example Apache log file,
 `logstash-tutorial.log`, that you downloaded earlier:
@@ -45,9 +61,13 @@ filebeat.inputs:
   paths:
     - /path/to/file/logstash-tutorial.log <1>
 output.logstash:
-  hosts: ["localhost:5044"]
+  hosts: ["170.65.88.60:5044"] <2>
 --------------------------------------------------------------------------------
 <1> Absolute path to the file or files that Filebeat processes.
+<2> The link in the list refers to a
+    https://discuss.elastic.co/t/dns-lookup-failure-failed-to-connect-to-backoff-async-tcp-no-such-host/313111/4[*TCP* connection],
+    so make sure the link is NOT prefixed with "http://" or "https://". Note that `170.65.88.60` is the host running
+    logstash instance and `5044` is the logstash port accepting the log lines.
 
 Save your changes.
 
@@ -412,7 +432,7 @@ Notice that the event now contains geographic location information:
 ==== Indexing Your Data into Elasticsearch
 
 Now that the web logs are broken down into specific fields, you're ready to get
-your data into Elasticsearch. 
+your data into Elasticsearch.
 
 TIP: {ess-leadin}
 


### PR DESCRIPTION
References
----------

- [DNS lookup failure | Failed to connect to backoff(async(tcp | no such host](https://discuss.elastic.co/t/dns-lookup-failure-failed-to-connect-to-backoff-async-tcp-no-such-host/313111)